### PR TITLE
Hide the overlay when clicking outside of the palette area

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -61,6 +61,7 @@ app.whenReady().then(() => {
 
     ipcMain.handle('externalUrlOpen', (event, url) => shell.openExternal(url))
     ipcMain.handle('panic', (event, msg) => panic(window, msg))
+    ipcMain.handle('hideWindow', () => window.hide())
 
     const shortcut = 'CommandOrControl+Shift+P'
     const ret = globalShortcut.register(shortcut, () => toggleWindowVisibility(window))

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,4 +3,5 @@ const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('electronAPI', {
     externalUrlOpen: (url) => ipcRenderer.invoke('externalUrlOpen', url),
     panic: (msg) => ipcRenderer.invoke('panic', msg),
+    hideWindow: () => ipcRenderer.invoke('hideWindow'),
 })

--- a/src/renderer/palette.js
+++ b/src/renderer/palette.js
@@ -14,6 +14,14 @@ const ICONS = {
     GOTO: '../../assets/goto.png',
 }
 
+// register click handlers that hide the window when clicking outside of the palette area
+document.getElementsByTagName('body')[0].addEventListener('click', () => {
+    window.electronAPI.hideWindow()
+})
+document.getElementById('palette').addEventListener('click', (event) => {
+    event.stopPropagation()
+})
+
 const makePalette = (searchInput, resultlist) => {
     let selectedResult = null
 


### PR DESCRIPTION
hide the overlay when clicking outside of the palette area. resolves #1