### PR TITLE
Fix broken bulk trade URLs for specific items

### DIFF
--- a/data/trade.py
+++ b/data/trade.py
@@ -25,6 +25,99 @@ bulk_tradable_ninja_categories: set[NinjaCategory] = {
     NinjaCategory.ESSENCES,
 }
 
+bulk_trade_tokens: dict[str, str] = {
+    'Orb of Alteration': 'alt',
+    'Orb of Fusing': 'fusing',
+    'Orb of Alchemy': 'alch',
+    'Chaos Orb': 'chaos',
+    "Gemcutter's Prism": 'gcp',
+    'Exalted Orb': 'exalted',
+    'Chromatic Orb': 'chrome',
+    "Jeweller's Orb": 'jewellers',
+    "Engineer's Orb": 'engineers',
+    'Orb of Chance': 'chance',
+    "Cartographer's Chisel": 'chisel',
+    'Orb of Scouring': 'scour',
+    'Blessed Orb': 'blessed',
+    'Orb of Regret': 'regret',
+    'Regal Orb': 'regal',
+    'Divine Orb': 'divine',
+    'Vaal Orb': 'vaal',
+    'Orbs of Annulment': 'annul',
+    'Wisdom Scroll': 'wisdom',
+    "Armourer's Scrap": 'scrap',
+    "Blacksmith's Whetstone": 'whetstone',
+    "Glassblower's Bauble": 'bauble',
+    'Orb of Transmutation': 'transmute',
+    'Orb of Augmentation': 'aug',
+    'Mirror of Kalandra': 'mirror',
+    'Eternal Orb': 'eternal',
+    "Facetor's Lens": 'facetors',
+    'Blessing of Xoph': 'blessing-xoph',
+    'Blessing of Tul': 'blessing-tul',
+    'Blessing of Esh': 'blessing-esh',
+    'Blessing of Uul-Netol': 'blessing-uul-netol',
+    'Blessing of Chayula': 'blessing-chayula',
+    # Exotic Currency
+    'Orb od Dominance': 'mavens-orb',
+    'Wild Crystallised Lifeforce': 'wild-lifeforce',
+    'Vivid Crystallised Lifeforce': 'vivid-lifeforce',
+    'Primal Crystallised Lifeforce': 'primal-lifeforce',
+    'Sacred Crystallised Lifeforce': 'sacred-lifeforce',
+    # Shards & Splinters
+    'Splinter of Xoph': 'splinter-xoph',
+    'Splinter of Tul': 'splinter-tul',
+    'Splinter of Esh': 'splinter-esh',
+    'Splinter of Uul-Netol': 'splinter-uul',
+    'Splinter of Chayula': 'splinter-chayula',
+    # Fragments & Sets
+    'Sacrifice at Dusk': 'dusk',
+    'Sacrifice at Midnight': 'mid',
+    'Sacrifice at Dawn': 'dawn',
+    'Sacrifice at Noon': 'noon',
+    'Mortal Grief': 'grief',
+    'Mortal Rage': 'rage',
+    'Mortal Hope': 'hope',
+    'Mortal Ignorance': 'ign',
+    'Fragment of the Hydra': 'hydra',
+    'Fragment of the Phoenix': 'phoenix',
+    'Fragment of the Minotaur': 'minot',
+    'Fragment of the Chimera': 'chimer',
+    'Offering to the Goddess': 'offer',
+    'Tribute to the Goddess': 'offer-tribute',
+    'Gift to the Goddess': 'offer-gift',
+    'Dedication to the Goddess': 'offer-dedication',
+    'Unrelenting Timeless Eternal Emblem': 'uber-timeless-eternal-emblem',
+    'Unrelenting Timeless Karui Emblem': 'uber-timeless-karui-emblem',
+    'Unrelenting Timeless Vaal Emblem': 'uber-timeless-vaal-emblem',
+    'Unrelenting Timeless Templar Emblem': 'uber-timeless-templar-emblem',
+    'Unrelenting Timeless Maraketh Emblem': 'uber-timeless-maraketh-emblem',
+    "Maven's Invitation: The Atlas": 'the-atlas',
+    "Maven's Invitation: The Formed": 'the-formed',
+    "Maven's Invitation: The Twisted": 'the-twisted',
+    "Maven's Invitation: The Forgotten": 'the-forgotten',
+    "Maven's Invitation: The Hidden": 'the-hidden',
+    "Maven's Invitation: The Feared": 'the-feared',
+    "Maven's Invitation: The Elderslayers": 'the-elderslayers',
+    # Scarabs
+    'Winged Breach Scarab': 'jewelled-breach-scarab',
+    'Winged Cartography Scarab': 'jewelled-cartography-scarab',
+    'Winged Reliquary Scarab': 'jewelled-reliquary-scarab',
+    'Winged Bestiary Scarab': 'jewelled-bestiary-scarab',
+    'Winged Shaper Scarab': 'jewelled-shaper-scarab',
+    'Winged Elder Scarab': 'jewelled-elder-scarab',
+    'Winged Sulphite Scarab': 'jewelled-sulphite-scarab',
+    'Winged Divination Scarab': 'jewelled-divination-scarab',
+    'Winged Torment Scarab': 'jewelled-torment-scarab',
+    'Winged Ambush Scarab': 'jewelled-ambush-scarab',
+    'Winged Harbinger Scarab': 'jewelled-harbinger-scarab',
+    'Winged Expedition Scarab': 'jewelled-expedition-scarab',
+    'Winged Legion Scarab': 'jewelled-legion-scarab',
+    'Winged Metamorph Scarab': 'jewelled-metamorph-scarab',
+    'Winged Blight Scarab': 'jewelled-blight-scarab',
+    'Winged Abyss Scarab': 'jewelled-abyss-scarab',
+}
+
 
 def automake_trade_url(category: NinjaCategory, item_name: str, base_item: str | None = None) -> URL:
     # NinjaCategory is a good (but not perfect) indicator of whether an item is bulk tradable.
@@ -64,18 +157,25 @@ def make_trade_url(type_: str, name: str | None = None) -> URL:
 
 
 def make_bulk_trade_url(name: str) -> URL:
+    c, div = bulk_trade_tokens['Chaos Orb'], bulk_trade_tokens['Divine Orb']
+
     if name == 'Divine Orb':
-        have = ['chaos']
+        have = [c]
     elif name == 'Chaos Orb':
-        have = ['divine']
+        have = [div]
     else:
-        have = ['chaos', 'divine']
+        have = [c, div]
+
+    # bulk trade utilizes a token alias instead of the actual name.
+    # most of the time that token is just the slugified name.
+    # there are some exceptions (mostly for older items), e.g. "Orb of Alteration" -> "alt".
+    want = bulk_trade_tokens.get(name, slugify(name))
 
     query = {
         'exchange': {
             'status': {'option': 'online'},
             'have': have,
-            'want': [slugify(name)],
+            'want': [want],
         }
     }
 


### PR DESCRIPTION
In the item exchange, items aren't identified by their human-readable name but a special tokenized version. Most of the time this is just the slugified name, but for some items it's completely different. Implement a mapping that handles these special cases.

Fixes #2