### PR TITLE
Eliminate flickering when showing/hiding palette

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2,6 +2,8 @@ const { app, BrowserWindow, ipcMain, shell, globalShortcut, dialog } = require('
 const path = require('node:path')
 const tray = require('./tray')
 
+app.commandLine.appendSwitch('wm-window-animations-disabled')
+
 const createWindow = (width, height) => {
     const win = new BrowserWindow({
         width: width,


### PR DESCRIPTION
Successively showing and hiding the palette caused animation flickering. Apparently this is a long standing Electron issue that has been fixed and regressed numerous times.

There are numerous bandaid-fixes on the internet, but the only reliable option seems to be to [disable the animation](https://github.com/electron/electron/issues/12130#issuecomment-627198990) altogether. I didn't care for it anyway.