### PR TITLE
Change default shortcut to Ctrl+P

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -67,7 +67,7 @@ app.whenReady().then(() => {
     ipcMain.handle('hideWindow', () => window.hide())
     ipcMain.handle('getSelectedLeague', () => userSettings.get('league'))
 
-    const shortcut = 'CommandOrControl+Shift+P'
+    const shortcut = 'CommandOrControl+P'
     const ret = globalShortcut.register(shortcut, () => toggleWindowVisibility(window))
     if (!ret) {
         panic(window, `Failed to register shortcut: ${shortcut}`)


### PR DESCRIPTION
The current shortcut `Ctrl+Shift+P` is too long and hard to press, especially when you use it frequently.
Change it to `Ctrl+P`. This is the canonical shortcut for printing in many applications, but I doubt many people of the target audience of this application still prints stuff, so I'm not concerned about shadowing it.

Note: `Ctrl+Shift+P` will most likely make a comeback as default shortcut for #10.