### PR TITLE
Make palette shortcut configurable in config file

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -75,7 +75,7 @@ app.whenReady().then(() => {
     })
 
     // register shortcuts
-    const shortcut = 'CommandOrControl+P'
+    const shortcut = userSettings.get('paletteShortcut')
     const ret = globalShortcut.register(shortcut, () => toggleWindowVisibility(window))
     if (!ret) {
         panic(window, `Failed to register shortcut: ${shortcut}`)

--- a/src/main/storage.js
+++ b/src/main/storage.js
@@ -17,6 +17,7 @@ const userSettingsSchema = {
         type: 'string',
         enum: ['challenge', 'challengehc', 'standard', 'hardcore'],
     },
+    paletteShortcut: { type: 'string' },
 }
 
 const userSettings = new Store({ userSettingsSchema })
@@ -27,6 +28,7 @@ setdefault(userSettings, 'tradeEnabled', true)
 setdefault(userSettings, 'tftEnabled', false)
 setdefault(userSettings, 'toolsEnabled', true)
 setdefault(userSettings, 'league', 'challenge')
+setdefault(userSettings, 'paletteShortcut', 'CommandOrControl+P')
 userSettings.getEnabledResultTypes = () => {
     const enabled = []
     if (userSettings.get('wikiEnabled')) enabled.push('wiki')


### PR DESCRIPTION
There should be a way to change the palette shortcut. Now is not a good time to make it configurable in the UI, so we'll at least offer the user to change it in the config file.

The config file is located at `%APPDATA&\poe-palette\config.json`. Check the Electron docs for [available key codes and modifiers](https://www.electronjs.org/docs/latest/api/accelerator#available-modifiers).

Partially addresses #20.