### PR TITLE
Add support for TFT channels of the current league

### DIFF
--- a/data/tft.py
+++ b/data/tft.py
@@ -65,4 +65,4 @@ def get_tft_channels(league_type: LeagueType) -> Generator[Entry, None, None]:
 
 
 def make_tft_url(server_id: str, channel_id: str) -> URL:
-    return f'https://discordapp.com/channels/{server_id}/{channel_id}'
+    return f'discord://-/channels/{server_id}/{channel_id}'

--- a/src/renderer/palette.js
+++ b/src/renderer/palette.js
@@ -11,10 +11,11 @@ const ICONS = {
     POEDB: '../../assets/poedb.png',
     NINJA: '../../assets/ninja.png',
     TRADE: '../../assets/trade.png',
+    TFT: '../../assets/tft.png',
     GOTO: '../../assets/goto.png',
 }
 
-const resultTypes = ['wiki', 'poedb', 'ninja', 'trade', 'tool']
+const resultTypes = ['wiki', 'poedb', 'ninja', 'trade', 'tft', 'tool']
 const specialSearchPrefixes = resultTypes.map(e => `${e}:`)
 
 // register click handlers that hide the window when clicking outside of the palette area
@@ -136,6 +137,14 @@ const makePalette = (searchInput, resultlist) => {
                     && r.trade_url !== null
                 ) {
                     addResultNode(ICONS.TRADE, `Trade for ${r.display_text}`, r.trade_url)
+                }
+                if (
+                    enabledResultTypes.includes('tft')
+                    && [null, 'tft'].includes(targetedSearch)
+                    && Object.prototype.hasOwnProperty.call(r, 'tft_url')
+                    && r.tft_url !== null
+                ) {
+                    addResultNode(ICONS.TFT, r.display_text, r.tft_url)
                 }
                 if (
                     enabledResultTypes.includes('tool')

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -2,7 +2,7 @@
 
 const POEPALETTE_MINISEARCH = new MiniSearch({
     fields: ['display_text'],
-    storeFields: ['display_text', 'wiki_url', 'poedb_url', 'ninja_url', 'trade_url', 'tool_url'],
+    storeFields: ['display_text', 'wiki_url', 'poedb_url', 'ninja_url', 'trade_url', 'tft_url', 'tool_url'],
 })
 
 const init_minisearch = async (league) => {


### PR DESCRIPTION
The app now includes TFT channels of the current league, e.g searching for `bulk ess` in the Ancestor league will show the results `bulk-essences-wtb-anc` and `bulk-essences-wts-anc`.

The TFT channels will be opened in the Discord desktop app, _not_ in the browser version.