### PR TITLE
Search field sometimes does not have focus when palette is opened

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -82,4 +82,9 @@ app.whenReady().then(() => {
     }
 })
 
+// propagate focus events to the respective renderer
+app.on('browser-window-focus', (event, window) => {
+    window.webContents.send('focusGained')
+})
+
 app.on('will-quit', () => globalShortcut.unregisterAll())

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -6,4 +6,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
     hideWindow: () => ipcRenderer.invoke('hideWindow'),
     onLeagueChanged: (callback) => ipcRenderer.on('leagueChanged', callback),
     onEnabledResultTypesChanged: (callback) => ipcRenderer.on('enabledResultTypesChanged', callback),
+    onFocusGained: (callback) => ipcRenderer.on('focusGained', callback),
 })

--- a/src/renderer/palette.js
+++ b/src/renderer/palette.js
@@ -35,6 +35,11 @@ const makePalette = (searchInput, resultlist) => {
         enabledResultTypes = resultTypes
     })
 
+    window.electronAPI.onFocusGained(() => {
+        searchInput.focus()
+        searchInput.setSelectionRange(0, searchInput.value.length)
+    })
+
     const addResultNode = (icon, text, target) => {
         const image = document.createElement('img')
         image.src = icon


### PR DESCRIPTION
This is annoying as you manually have to get focus on the search field before you can start typing.  
Fix this by propagating the browser-window-focus event to the palette window and then focus the search field.