### PR TITLE
Forget about selected result from old search

### DIFF
--- a/src/renderer/palette.js
+++ b/src/renderer/palette.js
@@ -81,6 +81,7 @@ const makePalette = (searchInput, resultlist) => {
     searchInput.addEventListener('input', () => {
         // clear previous search results
         resultlist.replaceChildren()
+        selectedResult = null
 
         // prepare search
         let term = searchInput.value.trim()


### PR DESCRIPTION
When selecting a result from the result list and then performing a new search, that result is still remembered as being selected, i.e. hitting enter will open it although it has nothing to do with the new search.  
Forget about the selected result when performing a new search.