### PR TITLE
Remove "Toggle Visibility" from tray menu

### DIFF
--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -101,8 +101,6 @@ exports.createTray = (leftClickCallback, window) => {
             },
         },
         { type: 'separator' },
-        { label: 'Toggle visibility', click: leftClickCallback },
-        { type: 'separator' },
         { label: 'Quit', role: 'quit' },
     ])
     tray.setContextMenu(contextMenu)


### PR DESCRIPTION
It was used during early stages of development, but serves no purpose any more.