### PR TITLE
Check for newer app version at start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.5.1",
       "license": "GPLv3",
       "dependencies": {
-        "electron-store": "^8.1.0"
+        "electron-store": "^8.1.0",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "stylelint-config-standard": "^34.0.0"
   },
   "dependencies": {
-    "electron-store": "^8.1.0"
+    "electron-store": "^8.1.0",
+    "semver": "^7.5.4"
   }
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2,8 +2,14 @@ const { app, BrowserWindow, ipcMain, shell, globalShortcut, dialog } = require('
 const path = require('node:path')
 const tray = require('./tray')
 const { userSettings } = require('./storage')
+const { checkForUpdates } = require('./update')
 
 app.commandLine.appendSwitch('wm-window-animations-disabled')
+
+// check for updates in background
+if (app.isPackaged) {
+    checkForUpdates()
+}
 
 const createWindow = (width, height) => {
     const win = new BrowserWindow({

--- a/src/main/update.js
+++ b/src/main/update.js
@@ -1,0 +1,45 @@
+const { app, dialog, shell } = require('electron')
+const semver = require('semver')
+const https = require('https')
+
+exports.checkForUpdates = () => {
+    const currentVersion = app.getVersion()
+
+    const reqOptions = {
+        protocol: 'https:',
+        host: 'api.github.com',
+        path: '/repos/flbraun/poe-palette/releases/latest',
+        headers: {
+            'User-Agent': 'flbraun/poe-palette',
+        },
+    }
+
+    https.get(reqOptions, (resp) => {
+        let data = ''
+
+        resp.on('data', (chunk) => {
+            data += chunk
+        })
+
+        resp.on('end', () => {
+            const respData = JSON.parse(data)
+            const latestVersion = respData.tag_name
+            const releasePage = respData.html_url
+
+            if (semver.lt(semver.coerce(currentVersion), semver.coerce(latestVersion))) {
+                let buttonClicked = dialog.showMessageBoxSync(null, {
+                    type: 'info',
+                    title: 'Update available!',
+                    message: 'A new version of PoE Palette is available!',
+                    detail: `${latestVersion} is available, you're running ${currentVersion}.\nOpen download page?`,
+                    buttons: ['Yes', 'No'],
+                })
+
+                if (buttonClicked === 0) { // 0 is index of 'Yes' button
+                    shell.openExternal(releasePage)
+                    app.quit()
+                }
+            }
+        })
+    })
+}


### PR DESCRIPTION
When the app starts, check for a newer app version.
If there is a newer release, offer to open the release page in the browser.
When the user chooses to open the release page, exit the app. The user is likely to download the newer release, removing the necessity to close the old app instance manually first.