### PR TITLE
Reduce disk size of the app

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -2,6 +2,29 @@ module.exports = {
     packagerConfig: {
         asar: true,
         icon: 'assets/mirror',
+        ignore: [
+            // Python source code
+            '^/data($|/)',
+            // misc dev stuff
+            '^/.github($|/)',
+            '^/.idea($|/)',
+            '^/.ruff_cache($|/)',
+            '^/.vscode($|/)',
+            '^/.venv($|/)',
+            '^/venv($|/)',
+            '^/.editorconfig$',
+            '^/.eslintrc.json$',
+            '^/src/main/.eslintrc.json$',
+            '^/src/renderer/.eslintrc.json$',
+            '^/.gitattributes$',
+            '^/.gitignore$',
+            '^/.npmrc$',
+            '^/.ruff.toml$',
+            '^/.stylelintrc.json$',
+            '^/README.md$',
+            '^/requirements.txt$',
+            '^/requirements-dev.txt$',
+        ],
     },
     rebuildConfig: {},
     makers: [


### PR DESCRIPTION
electron-builder copies a lot of unnecessary stuff into the packaged app.
Thin this bloat out by ignoring any non-essential file/directory in the packager's config.