### PR TITLE
Periodically check for newer data in background

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -5,7 +5,12 @@ const POEPALETTE_MINISEARCH = new MiniSearch({
     storeFields: ['display_text', 'wiki_url', 'poedb_url', 'ninja_url', 'trade_url', 'tft_url', 'tool_url'],
 })
 
-const init_minisearch = async (league) => {
+let currentLeague
+let dataTimestamp
+
+const initMinisearch = async (league) => {
+    currentLeague = league
+
     const url = `https://d2zmd9bpiyaqin.cloudfront.net/data-${league}.json`
     console.log(`loading search data from ${url}`)
 
@@ -27,6 +32,31 @@ const init_minisearch = async (league) => {
     POEPALETTE_MINISEARCH.addAll(content.data)
     console.timeEnd('search index building')
     console.log(`search index size: ${POEPALETTE_MINISEARCH.termCount}`)
+
+    dataTimestamp = Date.parse(response.headers.get('last-modified'))
 }
 
-window.electronAPI.onLeagueChanged((event, league) => init_minisearch(league))
+window.electronAPI.onLeagueChanged((event, league) => initMinisearch(league))
+
+const checkForDataUpdates = async () => {
+    const url = `https://d2zmd9bpiyaqin.cloudfront.net/data-${currentLeague}.json`
+
+    const response = await fetch(url, { method: 'HEAD' })
+    if (response.status !== 200) {
+        window.electronAPI.panic(
+            `Failed to check for data updates at ${url} (HTTP status ${response.status})`,
+        )
+        return
+    }
+
+    const lastModified = Date.parse(response.headers.get('last-modified'))
+
+    if (lastModified > dataTimestamp) {
+        console.log(`New data available at ${url}, reinitializing search index`)
+        initMinisearch(currentLeague)
+    } else {
+        console.log(`No new data available at ${url}`)
+    }
+}
+
+setInterval(checkForDataUpdates, 15 * 60 * 1000) // check every 15 minutes


### PR DESCRIPTION
Data for the search index is recalculated every 24 hours and made available to the clients via Cloudfront. Previously, the client would only get the latest data when starting the app, meaning users with long-running clients would miss out on the daily updates. 

Implement a HEAD check for newer data of the currently selected league and load it when found.

Resolves #47