### PR TITLE
proper usage of requests.sessions

### DIFF
--- a/data/leagues.py
+++ b/data/leagues.py
@@ -5,7 +5,7 @@ import http
 from tabulate import tabulate
 
 from .types import LeagueType
-from .utils import LoggedRequestsSession, slugify
+from .utils import DefaultHTTPSession, slugify
 
 
 @dataclasses.dataclass(frozen=True)
@@ -18,7 +18,7 @@ class League:
 
 @functools.cache
 def get_leagues() -> dict[LeagueType, League]:
-    session = LoggedRequestsSession()
+    session = DefaultHTTPSession()
 
     url = 'https://poe.ninja/api/data/getindexstate'
     res = session.get(url)

--- a/data/ninja.py
+++ b/data/ninja.py
@@ -6,7 +6,7 @@ from tabulate import tabulate
 
 from .leagues import League
 from .types import URL, NinjaCategory
-from .utils import LoggedRequestsSession
+from .utils import DefaultHTTPSession
 
 
 ninja_api_endpoint_for_category: dict[NinjaCategory, tuple[str, str]] = {  # (url_template, response_key)
@@ -111,19 +111,17 @@ class NinjaIndex:
 
 
 @functools.cache
-def get_ninja_index(league: League) -> NinjaIndex:
+def get_ninja_index(ninja_session: DefaultHTTPSession, league: League) -> NinjaIndex:
     """
     Downloads current data from ninja and makes it available as a sort-of index.
     """
-    session = LoggedRequestsSession()
-
     index = {}
 
     for category, endpoint_info in ninja_api_endpoint_for_category.items():
         url_template, response_attr = endpoint_info
         url = url_template.format(league=league.title)
 
-        res = session.get(url)
+        res = ninja_session.get(url)
         assert res.status_code == http.HTTPStatus.OK, f'{res.status_code} {url}'
 
         res_parsed = res.json()

--- a/data/tft.py
+++ b/data/tft.py
@@ -6,12 +6,12 @@ from collections.abc import Generator
 import emoji
 
 from .types import URL, LeagueType
-from .utils import Entry, LoggedRequestsSession
+from .utils import DefaultHTTPSession, Entry
 
 
 @functools.cache
 def get_channel_list(server_id: str) -> list[dict]:
-    session = LoggedRequestsSession()
+    session = DefaultHTTPSession()
 
     url = f'https://discordapp.com/api/v9/guilds/{server_id}/channels'
     headers = {


### PR DESCRIPTION
properly use request's `Session` instances to avoid creating a new connection for every HTTP request to frequently used services (poe.ninja and the wiki).  
use a descriptive user agent for requests to those services by default so they can identify the traffic from poe-palette.