### PR TITLE
Avoid horizontal flickering of palette

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -42,6 +42,7 @@
 
 html, body {
     height: 100%;
+    overflow-y: hidden;
 }
 
 body,


### PR DESCRIPTION
While typing in the search field, the palette would often flicker when the result list exceeded the available viewport height due to the vertical scroll bar (dis)appearing.